### PR TITLE
Don't use an array ref with around, which Moo doesn't seem to like

### DIFF
--- a/lib/Net/OpenStack/Compute.pm
+++ b/lib/Net/OpenStack/Compute.pm
@@ -244,13 +244,18 @@ sub _check_res {
     return 1;
 }
 
-around [qw( _get _post _delete )] => sub {
+my $around_sub = sub {
     my $orig = shift;
     my $self = shift;
     my $res = $self->$orig(@_);
     _check_res($res);
     return $res;
 };
+
+
+for my $s (qw( _get _post _delete )) {
+    around $s => $around_sub;
+}
 
 # ABSTRACT: Bindings for the OpenStack Compute API.
 


### PR DESCRIPTION
This trivial patch prevents this error from happening on my machine and allows me to run the _1_ test :)

```
$ prove -lrv t/00-load.t 
t/00-load.t .. 
1..1
strictures.pm extra testing active but couldn't load all modules. Missing were:

  indirect multidimensional bareword::filehandles

Extra testing is auto-enabled in checkouts only, so if you're the author
of a strictures using module you need to run:

  cpan indirect multidimensional bareword::filehandles

but these modules are not required by your users.
not ok 1 - use Net::OpenStack::Compute;

#   Failed test 'use Net::OpenStack::Compute;'
#   at t/00-load.t line 3.
#     Tried to use 'Net::OpenStack::Compute'.
#     Error:  The method 'ARRAY(0x15e2ce8)' is not found in the inheritance hierarchy for class Net::OpenStack::Compute at /usr/share/perl5/Class/Method/Modifiers.pm line 30
#   Class::Method::Modifiers::install_modifier('Net::OpenStack::Compute', 'around', 'ARRAY(0x15e2ce8)') called at /home/leto/local-lib/lib/perl5/Moo/_Utils.pm line 32
#   Moo::_Utils::_install_modifier('Net::OpenStack::Compute', 'around', 'ARRAY(0x15e2ce8)', 'CODE(0x153f628)') called at /home/leto/local-lib/lib/perl5/Moo.pm line 53
#   Moo::around('ARRAY(0x15e2ce8)', 'CODE(0x153f628)') called at /home/leto/git/Net-OpenStack-Compute/lib/Net/OpenStack/Compute.pm line 253
#   require Net/OpenStack/Compute.pm called at (eval 4) line 2
#   main::BEGIN() called at /usr/share/perl5/Class/Method/Modifiers.pm line 0
#   eval {...} called at /usr/share/perl5/Class/Method/Modifiers.pm line 0
#   eval 'package main;
# use Net::OpenStack::Compute @{$args[0]};
#1;
# 
# ;' called at /home/leto/local-lib/lib/perl5/Test/More.pm line 885
#   Test::More::_eval('package main;\x{a}use Net::OpenStack::Compute @{$args[0]};\x{a}1;\x{a}', 'ARRAY(0x1013620)') called at /home/leto/local-lib/lib/perl5/Test/More.pm line 860
#   Test::More::use_ok('Net::OpenStack::Compute') called at t/00-load.t line 3
# Compilation failed in require at (eval 4) line 2.
# BEGIN failed--compilation aborted at (eval 4) line 2.
# Looks like you failed 1 test of 1.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests 

Test Summary Report
-------------------
t/00-load.t (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=1, Tests=1,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.08 cusr  0.00 csys =  0.10 CPU)
Result: FAIL
```
